### PR TITLE
Orientations of cameras not required

### DIFF
--- a/SurfaceReconstruction/SurfaceReconstruction/Geometry/RayTracer.cpp
+++ b/SurfaceReconstruction/SurfaceReconstruction/Geometry/RayTracer.cpp
@@ -396,12 +396,15 @@ void RayTracer::findIntersectionsForViewSamplePairs(
 		ray.org[0] = (float)  startPosWS.x;
 		ray.org[1] = (float)  startPosWS.y;
 		ray.org[2] = (float) -startPosWS.z; // conversion: left-handed to right-handed system
-		
-		// get camera/sample coordinate system
-		const Quaternion &cameraOrientation = view.getCamera().getOrientation();
-		Vector3 t0, t1;
-		cameraOrientation.rotateVector(t0, Vector3(1.0f, 0.0f, 0.0f)); //cameraOrientation.rotateVector(t1, Vector3(0.0f, 1.0f, 0.0f));
-		cameraOrientation.rotateVector(t1, Vector3(0.0f, 1.0f, 0.0f));
+
+		// calculating basis orthogonal to ray from camera to sample
+		const Vector3 &samplePosWS = samples.getPositionWS(sampleIdx);
+		const Vector3 toSamplePosWS = samplePosWS - startPosWS;
+		Vector3 t0 = (toSamplePosWS.x != 0 || toSamplePosWS.y != 0) ? Vector3(0.0, 0.0, 1.0) : Vector3(1.0, 0.0, 0.0);
+		Vector3 t1 = toSamplePosWS.crossProduct(t0);
+		t0 = toSamplePosWS.crossProduct(t1);
+		t0.normalize();
+		t1.normalize();
 
 		// get data for sampling pattern
 		const Real sampleScale = samples.getScale(sampleIdx);
@@ -411,8 +414,7 @@ void RayTracer::findIntersectionsForViewSamplePairs(
 		// ray direction = towards sampling point of sampling pattern of sample patch
 		Vector2 offset = getRelativeSamplingOffset(localSamplingCoords, raysPerViewSamplePair);
 		offset *= sampleScale;
-		
-		const Vector3 &samplePosWS = samples.getPositionWS(sampleIdx);
+
 		const Vector3 targetWS = samplePosWS + t0 * offset.x + t1 * offset.y;
 		const Vector3 toTargetWS = targetWS - startPosWS;
 		ray.dir[0] = (float)  toTargetWS.x;


### PR DESCRIPTION
This makes possible to run TSR from samples+cameras, where cameras in fact described only with positions (previously rotation also required):

```
id = 0
name = view0
focal_length = 1.0
principle_point = 0.5 0.5
pixel_aspect_ratio = 1
camera_distortion = 0 0
translation = -3.38376 8.54135 -7.59943
rotation = -1 0 0 0 -1 0 0 0 -1
```

P.S. Rotation should be minus eye matrix in accordance to [these lines](https://github.com/SamirAroudj/TSR/blob/0889fcd30245f355bc04203d0cc4869ec63c94a6/SurfaceReconstruction/SurfaceReconstruction/Scene/CapturedScene.cpp#L192-L193).